### PR TITLE
Refactor: O(1) grid indexing, lock-free hourly supply/demand aggregation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,47 +4,133 @@ using System.Linq;
 using NetTopologySuite.Geometries;
 using ProjNet.CoordinateSystems;
 using ProjNet.CoordinateSystems.Transformations;
-using SpatialAggregation; // Added for SpatialAggregator
+using SpatialAggregation;
 
 class Program
 {
     static void Main()
     {
-        // Set up parameters
-        int nPoints = 5000;
-        double lonMin = -74.1, lonMax = -73.9, latMin = 40.7, latMax = 40.85;
-        double gridSize = 500; // 500m grid cells
-        var random = new Random();
+        // ----------------------------------------------------------------
+        // Parameters
+        // ----------------------------------------------------------------
+        const int    nEvents   = 5000;          // events per type (supply / demand)
+        const double lonMin    = -74.1;
+        const double lonMax    = -73.9;
+        const double latMin    =  40.7;
+        const double latMax    =  40.85;
+        const double gridSize  = 500;           // 500 m cells
+        const int    minThresh = 5;             // minimum events to classify a zone
+        var random = new Random(42);
 
-        // Generate random points
-        List<Coordinate> puCoordinates = SpatialAggregator.GenerateRandomPoints(nPoints, lonMin, lonMax, latMin, latMax, random);
-        List<Coordinate> doCoordinates = SpatialAggregator.GenerateRandomPoints(nPoints, lonMin, lonMax, latMin, latMax, random);
+        // ----------------------------------------------------------------
+        // 1. Generate raw WGS84 coordinates
+        //    Supply  = drivers becoming available  (completing a dropoff)
+        //    Demand  = passengers requesting a ride (originating a pickup)
+        // ----------------------------------------------------------------
+        List<Coordinate> supplyRaw = SpatialAggregator.GenerateRandomPoints(
+            nEvents, lonMin, lonMax, latMin, latMax, random);
 
-        // Define the CRS and transformation
-        var wgs84 = GeographicCoordinateSystem.WGS84;
-        var mercator = ProjectedCoordinateSystem.WebMercator;
-        var coordinateTransformFactory = new CoordinateTransformationFactory();
-        var coordinateTransformation = coordinateTransformFactory.CreateFromCoordinateSystems(wgs84, mercator);
+        List<Coordinate> demandRaw = SpatialAggregator.GenerateRandomPoints(
+            nEvents, lonMin, lonMax, latMin, latMax, random);
 
-        // Transform coordinates
-        List<Coordinate> puTransformed = SpatialAggregator.TransformCoordinates(puCoordinates, coordinateTransformation);
-        List<Coordinate> doTransformed = SpatialAggregator.TransformCoordinates(doCoordinates, coordinateTransformation);
-
-        // Calculate bounding box
-        Envelope boundingBox = SpatialAggregator.CalculateBoundingBox(puTransformed, doTransformed);
-
-        // Create grid
-        List<Polygon> gridCells = SpatialAggregator.CreateGrid(boundingBox, gridSize);
-
-        // Count points in grid
-        Dictionary<Polygon, (int PUCount, int DOCount)> aggregatedResults = SpatialAggregator.CountPointsInGrid(gridCells, puTransformed, doTransformed);
-
-        // Output results
-        foreach (var result in aggregatedResults)
+        // Assign each event a random hour of day [0-23].
+        int[] supplyHours = new int[nEvents];
+        int[] demandHours = new int[nEvents];
+        for (int i = 0; i < nEvents; i++)
         {
-            if (result.Value.PUCount > 0 || result.Value.DOCount > 0)
+            supplyHours[i] = random.Next(0, 24);
+            demandHours[i] = random.Next(0, 24);
+        }
+
+        // ----------------------------------------------------------------
+        // 2. Project WGS84 → Web Mercator (EPSG:3857) for metre-based grid
+        // ----------------------------------------------------------------
+        var transformFactory = new CoordinateTransformationFactory();
+        var transform = transformFactory.CreateFromCoordinateSystems(
+            GeographicCoordinateSystem.WGS84,
+            ProjectedCoordinateSystem.WebMercator);
+
+        Coordinate[] supplyProjected = SpatialAggregator.TransformCoordinates(supplyRaw, transform);
+        Coordinate[] demandProjected = SpatialAggregator.TransformCoordinates(demandRaw, transform);
+
+        // ----------------------------------------------------------------
+        // 3. Build the grid envelope from all projected points
+        // ----------------------------------------------------------------
+        Envelope boundingBox = SpatialAggregator.CalculateBoundingBox(supplyProjected, demandProjected);
+
+        // ----------------------------------------------------------------
+        // 4. Assemble GridEvent list
+        // ----------------------------------------------------------------
+        var events = new List<GridEvent>(nEvents * 2);
+        for (int i = 0; i < nEvents; i++)
+        {
+            events.Add(new GridEvent(supplyProjected[i].X, supplyProjected[i].Y,
+                                     supplyHours[i], EventType.Supply));
+            events.Add(new GridEvent(demandProjected[i].X, demandProjected[i].Y,
+                                     demandHours[i], EventType.Demand));
+        }
+
+        // ----------------------------------------------------------------
+        // 5. Aggregate — O(1) cell lookup, lock-free parallel writes
+        // ----------------------------------------------------------------
+        List<HourlyZoneResult> results = SpatialAggregator.AggregateHourly(
+            events, boundingBox, gridSize, minThresh);
+
+        // ----------------------------------------------------------------
+        // 6. Summary
+        // ----------------------------------------------------------------
+        int countSupply      = results.Count(r => r.Status == ZoneStatus.NetSupply);
+        int countDemand      = results.Count(r => r.Status == ZoneStatus.NetDemand);
+        int countBalanced    = results.Count(r => r.Status == ZoneStatus.Balanced);
+        int countUnsupported = results.Count(r => r.Status == ZoneStatus.Unsupported);
+
+        Console.WriteLine("=== Grid Aggregate — Hourly Supply/Demand Summary ===");
+        Console.WriteLine($"Grid size      : {gridSize} m");
+        Console.WriteLine($"Activity threshold: {minThresh} events/cell-hour");
+        Console.WriteLine($"Total active cell-hours : {results.Count}");
+        Console.WriteLine($"  Net Supply   (drivers > requests) : {countSupply}");
+        Console.WriteLine($"  Net Demand   (requests > drivers) : {countDemand}");
+        Console.WriteLine($"  Balanced     (supply == demand)   : {countBalanced}");
+        Console.WriteLine($"  Unsupported  (below threshold)    : {countUnsupported}");
+        Console.WriteLine();
+
+        // ----------------------------------------------------------------
+        // 7. Per-cell detail — ordered by hour then cell index
+        // ----------------------------------------------------------------
+        Console.WriteLine("Hour | Cell (X, Y) | Supply | Demand |   Net | Status");
+        Console.WriteLine("-----|-------------|--------|--------|-------|------------");
+
+        double originX = boundingBox.MinX;
+        double originY = boundingBox.MinY;
+
+        foreach (var r in results
+            .Where(r => r.Status != ZoneStatus.Unsupported)
+            .OrderBy(r => r.Hour)
+            .ThenBy(r => r.CellX)
+            .ThenBy(r => r.CellY))
+        {
+            // Centroid of the cell in Web Mercator metres (useful for downstream mapping)
+            double centroidX = originX + (r.CellX + 0.5) * gridSize;
+            double centroidY = originY + (r.CellY + 0.5) * gridSize;
+
+            Console.WriteLine(
+                $" {r.Hour:D2}  | ({r.CellX,3},{r.CellY,3}) [{centroidX:F0},{centroidY:F0}]" +
+                $" | Supply: {r.Supply,4} | Demand: {r.Demand,4} | Net: {r.Net,+4} | {r.Status}");
+        }
+
+        // Unsupported zones listed separately for operational awareness
+        if (countUnsupported > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"--- {countUnsupported} Unsupported cell-hours " +
+                              $"(below {minThresh}-event threshold) ---");
+            foreach (var r in results
+                .Where(r => r.Status == ZoneStatus.Unsupported)
+                .OrderBy(r => r.Hour).ThenBy(r => r.CellX).ThenBy(r => r.CellY))
             {
-                Console.WriteLine($"Grid Cell: {result.Key.Coordinates[0].X},{result.Key.Coordinates[0].Y}; PU Count: {result.Value.PUCount}; DO Count: {result.Value.DOCount}");
+                Console.WriteLine(
+                    $" {r.Hour:D2}  | ({r.CellX,3},{r.CellY,3}) " +
+                    $"| Supply: {r.Supply} | Demand: {r.Demand}");
             }
         }
     }

--- a/SpatialAggregator.cs
+++ b/SpatialAggregator.cs
@@ -1,17 +1,63 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NetTopologySuite.Geometries;
-using ProjNet.CoordinateSystems;
 using ProjNet.CoordinateSystems.Transformations;
 
 namespace SpatialAggregation
 {
+    // -----------------------------------------------------------------------
+    // Domain types
+    // -----------------------------------------------------------------------
+
+    /// <summary>Supply = driver becoming available; Demand = passenger requesting a ride.</summary>
+    public enum EventType { Supply, Demand }
+
+    /// <summary>
+    /// Classification of a grid cell in a given hour bucket.
+    ///   NetSupply   – more available drivers than ride requests
+    ///   NetDemand   – more ride requests than available drivers
+    ///   Balanced    – supply equals demand (and above the activity threshold)
+    ///   Unsupported – total activity below the minimum threshold; no reliable signal
+    /// </summary>
+    public enum ZoneStatus { Unsupported, NetSupply, NetDemand, Balanced }
+
+    /// <summary>A single rideshare event (driver available or passenger request) in projected space.</summary>
+    /// <param name="X">Web Mercator X (metres).</param>
+    /// <param name="Y">Web Mercator Y (metres).</param>
+    /// <param name="Hour">Hour of day [0–23].</param>
+    /// <param name="Type">Supply (driver) or Demand (passenger).</param>
+    public record GridEvent(double X, double Y, int Hour, EventType Type);
+
+    /// <summary>Aggregated result for one cell/hour combination.</summary>
+    public record HourlyZoneResult(
+        int CellX, int CellY, int Hour,
+        int Supply, int Demand,
+        ZoneStatus Status)
+    {
+        /// <summary>Positive = net driver surplus; negative = net passenger surplus.</summary>
+        public int Net => Supply - Demand;
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregator
+    // -----------------------------------------------------------------------
+
     public static class SpatialAggregator
     {
-        public static List<Coordinate> GenerateRandomPoints(int nPoints, double lonMin, double lonMax, double latMin, double latMax, Random random)
+        // -------------------------------------------------------------------
+        // Point generation (unchanged – used for test data)
+        // -------------------------------------------------------------------
+
+        public static List<Coordinate> GenerateRandomPoints(
+            int nPoints,
+            double lonMin, double lonMax,
+            double latMin, double latMax,
+            Random random)
         {
-            var points = new List<Coordinate>();
+            var points = new List<Coordinate>(nPoints);
             for (int i = 0; i < nPoints; i++)
             {
                 double lon = random.NextDouble() * (lonMax - lonMin) + lonMin;
@@ -21,88 +67,134 @@ namespace SpatialAggregation
             return points;
         }
 
-        public static List<Coordinate> TransformCoordinates(List<Coordinate> coordinates, ICoordinateTransformation transformation)
+        // -------------------------------------------------------------------
+        // Coordinate transformation — parallelised; MathTransform is stateless
+        // for well-known projections (WGS84 → WebMercator) so parallel reads
+        // are safe.
+        // -------------------------------------------------------------------
+
+        public static Coordinate[] TransformCoordinates(
+            IReadOnlyList<Coordinate> coordinates,
+            ICoordinateTransformation transformation)
         {
-            var transformedCoordinates = new List<Coordinate>();
-            foreach (var point in coordinates)
+            var mathTransform = transformation.MathTransform;
+            var result = new Coordinate[coordinates.Count];
+
+            Parallel.For(0, coordinates.Count, i =>
             {
-                // Create a double array for the transformation input
-                double[] transformedPoint = transformation.MathTransform.Transform(new double[] { point.X, point.Y });
-                // Create a new Coordinate from the transformed double array
-                transformedCoordinates.Add(new Coordinate(transformedPoint[0], transformedPoint[1]));
-            }
-            return transformedCoordinates;
+                var pt = coordinates[i];
+                double[] t = mathTransform.Transform(new[] { pt.X, pt.Y });
+                result[i] = new Coordinate(t[0], t[1]);
+            });
+
+            return result;
         }
 
-        public static Envelope CalculateBoundingBox(List<Coordinate> puTransformed, List<Coordinate> doTransformed)
+        // -------------------------------------------------------------------
+        // Bounding box — single pass, no LINQ allocation
+        // -------------------------------------------------------------------
+
+        public static Envelope CalculateBoundingBox(
+            IReadOnlyList<Coordinate> supply,
+            IReadOnlyList<Coordinate> demand)
         {
-            var allPoints = puTransformed.Concat(doTransformed).ToList();
-            double minX = allPoints.Min(p => p.X);
-            double minY = allPoints.Min(p => p.Y);
-            double maxX = allPoints.Max(p => p.X);
-            double maxY = allPoints.Max(p => p.Y);
+            double minX = double.MaxValue, minY = double.MaxValue;
+            double maxX = double.MinValue, maxY = double.MinValue;
+
+            foreach (var p in supply)
+            {
+                if (p.X < minX) minX = p.X;
+                if (p.Y < minY) minY = p.Y;
+                if (p.X > maxX) maxX = p.X;
+                if (p.Y > maxY) maxY = p.Y;
+            }
+            foreach (var p in demand)
+            {
+                if (p.X < minX) minX = p.X;
+                if (p.Y < minY) minY = p.Y;
+                if (p.X > maxX) maxX = p.X;
+                if (p.Y > maxY) maxY = p.Y;
+            }
+
             return new Envelope(minX, maxX, minY, maxY);
         }
 
-        public static List<Polygon> CreateGrid(Envelope boundingBox, double gridSize)
+        // -------------------------------------------------------------------
+        // Core aggregation
+        //
+        // Algorithm:
+        //   1. Pre-allocate int[24, gridWidth, gridHeight] arrays for supply
+        //      and demand counts.
+        //   2. For each event, compute its cell index in O(1) using floor
+        //      arithmetic — no geometric loop, no Polygon.Contains().
+        //   3. Write to the array with Interlocked.Increment — zero lock
+        //      contention, full parallel throughput.
+        //   4. Single classification pass: emit only cell-hours with activity.
+        // -------------------------------------------------------------------
+
+        /// <param name="events">All supply and demand events in projected (metre) space.</param>
+        /// <param name="gridOrigin">Bounding envelope that defines the grid origin and extent.</param>
+        /// <param name="gridSize">Cell size in metres (e.g. 500).</param>
+        /// <param name="minActivityThreshold">
+        ///   Minimum total events (supply + demand) required for a cell-hour to
+        ///   be classified as NetSupply / NetDemand / Balanced. Below this value
+        ///   the zone is marked Unsupported.
+        /// </param>
+        public static List<HourlyZoneResult> AggregateHourly(
+            IReadOnlyList<GridEvent> events,
+            Envelope gridOrigin,
+            double gridSize,
+            int minActivityThreshold = 5)
         {
-            var gridCells = new List<Polygon>();
-            var geometryFactory = new GeometryFactory();
+            int gridWidth  = (int)Math.Ceiling(gridOrigin.Width  / gridSize);
+            int gridHeight = (int)Math.Ceiling(gridOrigin.Height / gridSize);
+            double originX = gridOrigin.MinX;
+            double originY = gridOrigin.MinY;
 
-            for (double x = boundingBox.MinX; x < boundingBox.MaxX; x += gridSize)
+            // Pre-allocate accumulators — indexed [hour, cellX, cellY].
+            // Default value of int[] elements is 0, so no explicit init needed.
+            int[,,] supplyCounts = new int[24, gridWidth, gridHeight];
+            int[,,] demandCounts = new int[24, gridWidth, gridHeight];
+
+            // Parallel accumulation — lock-free via Interlocked.Increment.
+            Parallel.ForEach(events, evt =>
             {
-                for (double y = boundingBox.MinY; y < boundingBox.MaxY; y += gridSize)
-                {
-                    var envelope = new Envelope(x, x + gridSize, y, y + gridSize);
-                    gridCells.Add((Polygon)geometryFactory.ToGeometry(envelope));
-                }
-            }
-            return gridCells;
-        }
+                int cx = (int)Math.Floor((evt.X - originX) / gridSize);
+                int cy = (int)Math.Floor((evt.Y - originY) / gridSize);
 
-        private static readonly object _lock = new object();
+                // Guard against floating-point edge cases at the boundary.
+                if (cx < 0 || cx >= gridWidth || cy < 0 || cy >= gridHeight) return;
 
-        public static Dictionary<Polygon, (int PUCount, int DOCount)> CountPointsInGrid(List<Polygon> gridCells, List<Coordinate> puCoordinates, List<Coordinate> doCoordinates)
-        {
-            var results = new Dictionary<Polygon, (int PUCount, int DOCount)>();
-            foreach (var cell in gridCells)
-            {
-                results[cell] = (0, 0);
-            }
-
-            Parallel.ForEach(puCoordinates, puPoint =>
-            {
-                var pointGeometry = new Point(puPoint);
-                foreach (var cell in gridCells)
-                {
-                    if (cell.Contains(pointGeometry))
-                    {
-                        lock (_lock)
-                        {
-                            var counts = results[cell];
-                            results[cell] = (counts.PUCount + 1, counts.DOCount);
-                        }
-                        break;
-                    }
-                }
+                if (evt.Type == EventType.Supply)
+                    Interlocked.Increment(ref supplyCounts[evt.Hour, cx, cy]);
+                else
+                    Interlocked.Increment(ref demandCounts[evt.Hour, cx, cy]);
             });
 
-            Parallel.ForEach(doCoordinates, doPoint =>
+            // Classification pass — O(24 × gridWidth × gridHeight).
+            var results = new List<HourlyZoneResult>();
+
+            for (int hr = 0; hr < 24; hr++)
+            for (int cx = 0; cx < gridWidth; cx++)
+            for (int cy = 0; cy < gridHeight; cy++)
             {
-                var pointGeometry = new Point(doPoint);
-                foreach (var cell in gridCells)
-                {
-                    if (cell.Contains(pointGeometry))
+                int supply = supplyCounts[hr, cx, cy];
+                int demand = demandCounts[hr, cx, cy];
+                int total  = supply + demand;
+
+                if (total == 0) continue;   // completely empty cell-hour — skip
+
+                ZoneStatus status = total < minActivityThreshold
+                    ? ZoneStatus.Unsupported
+                    : (supply - demand) switch
                     {
-                        lock (_lock)
-                        {
-                            var counts = results[cell];
-                            results[cell] = (counts.PUCount, counts.DOCount + 1);
-                        }
-                        break;
-                    }
-                }
-            });
+                        > 0 => ZoneStatus.NetSupply,
+                        < 0 => ZoneStatus.NetDemand,
+                        _   => ZoneStatus.Balanced
+                    };
+
+                results.Add(new HourlyZoneResult(cx, cy, hr, supply, demand, status));
+            }
 
             return results;
         }


### PR DESCRIPTION
Replace O(n×m) Polygon.Contains loop with direct floor-arithmetic cell index computation, eliminating all geometric intersection testing from the hot path.

Key changes:
- Add EventType enum (Supply=driver, Demand=passenger), ZoneStatus enum (NetSupply / NetDemand / Balanced / Unsupported), GridEvent and HourlyZoneResult record types.
- New AggregateHourly() method: pre-allocates int[24,W,H] arrays and uses Interlocked.Increment for fully lock-free parallel writes. Classification pass emits per-cell-hour ZoneStatus after aggregation.
- Remove CountPointsInGrid() and the single global _lock that serialised all parallel work.
- Parallelise TransformCoordinates() with Parallel.For (was sequential).
- Optimise CalculateBoundingBox() to a single pass with no LINQ allocation.
- Program.cs updated to the supply/demand event model with per-hour detail output including cell centroids in projected space.

https://claude.ai/code/session_01LukxqFaV3ASUx599fYHShA